### PR TITLE
Package.swift: `upToNextMajor(from:)`の Before / After を追記

### DIFF
--- a/2021/2021_4q.md
+++ b/2021/2021_4q.md
@@ -173,11 +173,13 @@ FY2021 4Q（2022/01/01 〜 2022/03/31）のトレンドを紹介します。
     .package(url: String, .branch(String))
     .package(url: String, .revision(String))
     .package(url: String, .exact("1.2.0"))
+    .package(url: String, .upToNextMajor(from: "1.2.0"))
     
     // After
     .package(url: String, branch: String)
     .package(url: String, revision: String)
     .package(url: String, exact: "1.2.0")
+    .package(url: String, from: "1.2.0")
     ```
 - パッチバージョンなしのセマンティックバージョンを解決できるようになった
   - 例: `1.2` → `1.2.0`


### PR DESCRIPTION
`Package.swift`について、`.upToNextMajor(from:)`の Before / After を追記しました。（たぶんこれで合ってるとは思うのですが；

Apple Document: `upToNextMajor(from:)` - Deprecated
https://developer.apple.com/documentation/swift_packages/package/dependency/requirement/2878218-uptonextmajor

Implementation:
https://github.com/apple/swift-package-manager/blob/e25a590dc455baa430f2ec97eacc30257c172be2/Sources/PackageDescription/PackageDependency.swift#L179-L203

参考PR:
https://github.com/YusukeHosonuma/Swift-Evolution-Browser/pull/59/files